### PR TITLE
Get rid of unchanged arrays and objects in diffs

### DIFF
--- a/test/json_diff_ex_test.exs
+++ b/test/json_diff_ex_test.exs
@@ -41,6 +41,27 @@ defmodule JsonDiffExTest do
     comparediff(s1, s2, res)
   end
 
+  test "check the same object" do
+    s1 = ~s({"1": [1,2,3], "2": 1})
+    j1 = Poison.decode!(s1)
+    assert diff(j1, j1) == %{}
+    # jsondiffpatch returns undefined
+  end
+
+  test "check object diff not changed" do
+    s1 = ~s({"1": 1, "2": 2})
+    s2 = ~s({"1": 2, "2": 2})
+    res = %{"1" => [1, 2]}
+    comparediff(s1, s2, res)
+  end
+
+  test "check array diff not changed" do
+    s1 = ~s({"1": 1, "2": [1]})
+    s2 = ~s({"1": 2, "2": [1]})
+    res = %{"1" => [1, 2]}
+    comparediff(s1, s2, res)
+  end
+
   test "check array diff all changed" do
     s1 = ~s({"1": [1,2,3]})
     s2 = ~s({"1": [4,5,6]})


### PR DESCRIPTION
This fixes that `diff(%{a: 1, b: [2, 3], c: %{d: 4, e: 5}}, %{a: 6, b: [2, 3], c: %{d: 4, e: 5}})` returns not `%{a: [1, 6]}` but `%{a: [1, 6], b: %{"_t" => "a"}, c: %{}}`.
