### PR TITLE
strict_equality false

### DIFF
--- a/lib/json_diff_ex.ex
+++ b/lib/json_diff_ex.ex
@@ -137,16 +137,14 @@ defmodule JsonDiffEx do
   @spec do_diff(binary | integer | float, binary | integer | float) :: map | nil
   defp do_diff(i1, i2, opts) when not (is_list(i1) and is_list(i2))
                     and not (is_map(i1) and is_map(i2)) do
-    if Keyword.get(opts, :strict_equality, @default_strict_equality) do
-      case i1 === i2 do
-        true -> nil
-        false -> [i1, i2]
-      end
+    compare = if Keyword.get(opts, :strict_equality, @default_strict_equality) do
+      &===/2
     else
-      case i1 == i2 do
-        true -> nil
-        false -> [i1, i2]
-      end
+      &==/2
+    end
+    case compare.(i1, i2) do
+      true -> nil
+      false -> [i1, i2]
     end
   end
 

--- a/lib/json_diff_ex.ex
+++ b/lib/json_diff_ex.ex
@@ -61,6 +61,8 @@ defmodule JsonDiffEx do
 
   """
 
+  @default_strict_equality true
+
   @spec split_underscore_map({binary, list}) :: boolean
   defp split_underscore_map({<<"_", _>>, [value, 0, 0]}) when is_map(value) do
     false
@@ -96,8 +98,10 @@ defmodule JsonDiffEx do
     end
   end
 
+  defp do_diff(l1, l2, opts \\ [])
+
   @spec do_diff(list, list) :: map | nil
-  defp do_diff(l1, l2) when is_list(l1) and is_list(l2) do
+  defp do_diff(l1, l2, opts) when is_list(l1) and is_list(l2) do
     new_list = List.myers_difference(l1, l2)
     |> Enum.reduce({0, %{}}, fn
       {:eq, equal}, {count, acc} ->
@@ -131,16 +135,23 @@ defmodule JsonDiffEx do
   end
 
   @spec do_diff(binary | integer | float, binary | integer | float) :: map | nil
-  defp do_diff(i1, i2) when not (is_list(i1) and is_list(i2))
+  defp do_diff(i1, i2, opts) when not (is_list(i1) and is_list(i2))
                     and not (is_map(i1) and is_map(i2)) do
-    case i1 === i2 do
-      true -> nil
-      false -> [i1, i2]
+    if Keyword.get(opts, :strict_equality, @default_strict_equality) do
+      case i1 === i2 do
+        true -> nil
+        false -> [i1, i2]
+      end
+    else
+      case i1 == i2 do
+        true -> nil
+        false -> [i1, i2]
+      end
     end
   end
 
   @spec do_diff(map, map) :: map | nil
-  defp do_diff(map1, map2) when is_map(map1) and is_map(map2) do
+  defp do_diff(map1, map2, opts) when is_map(map1) and is_map(map2) do
     keys_non_uniq = Enum.concat(Map.keys(map1), Map.keys(map2))
     diff = keys_non_uniq
     |> Enum.uniq
@@ -148,7 +159,7 @@ defmodule JsonDiffEx do
       case Map.has_key?(map1, k) do
         true ->
           case Map.has_key?(map2, k) do
-            true -> {k, do_diff(Map.get(map1, k), Map.get(map2, k))}
+            true -> {k, do_diff(Map.get(map1, k), Map.get(map2, k), opts)}
             false -> {k, [Map.get(map1, k), 0, 0]}
           end
         false -> {k, [Map.get(map2, k)]}
@@ -169,8 +180,8 @@ defmodule JsonDiffEx do
   numbers and boolean.
   """
   @spec diff(map, map) :: map
-  def diff(map1, map2) when is_map(map1) and is_map(map2) do
-    case do_diff(map1, map2) do
+  def diff(map1, map2, opts \\ []) when is_map(map1) and is_map(map2) do
+    case do_diff(map1, map2, opts) do
       nil -> %{}
       map -> map
     end

--- a/test/json_diff_ex_test.exs
+++ b/test/json_diff_ex_test.exs
@@ -156,6 +156,24 @@ defmodule JsonDiffExTest do
     comparediff(s1, s2, res)
   end
 
+  test "check === with same numeric type" do
+    m1 = %{"1" => 4, "2" => 2}
+    m2 = %{"1" => 4, "2" => 2}
+    assert diff(m1, m2) == %{}
+  end
+
+  test "check == but different numeric type" do
+    m1 = %{"1" => 4, "2" => 2}
+    m2 = %{"1" => 4.0, "2" => 2}
+    assert diff(m1, m2) == %{"1" => [4, 4.0]}
+  end
+
+  test "check === but different numeric type" do
+    m1 = %{"1" => 4, "2" => 2}
+    m2 = %{"1" => 4.0, "2" => 2}
+    assert diff(m1, m2) == %{}
+  end
+
   test "check basic patch" do
     s1 = ~s({"1": 1})
     s2 = ~s({"1": 2})

--- a/test/json_diff_ex_test.exs
+++ b/test/json_diff_ex_test.exs
@@ -171,7 +171,7 @@ defmodule JsonDiffExTest do
   test "check === but different numeric type" do
     m1 = %{"1" => 4, "2" => 2}
     m2 = %{"1" => 4.0, "2" => 2}
-    assert diff(m1, m2) == %{}
+    assert diff(m1, m2, strict_equality: false) == %{}
   end
 
   test "check basic patch" do


### PR DESCRIPTION
added options, so you put "strict_equality: false" if you want to compare with less strict manner