### PR TITLE
Update USDA url to https

### DIFF
--- a/profile/get_usda_json.exs
+++ b/profile/get_usda_json.exs
@@ -1,5 +1,5 @@
 HTTPoison.start
-case HTTPoison.get("http://www.usda.gov/data.json") do
+case HTTPoison.get("https://www.usda.gov/data.json") do
   {:ok, %HTTPoison.Response{body: body, status_code: 200}} -> File.write!("profile/usda.json", body)
 end
 case HTTPoison.get("https://edg.epa.gov/data.json") do


### PR DESCRIPTION
It appears the USDA link is now https-only:

```
$ MIX_ENV=test mix run profile/get_usda_json.exs
** (CaseClauseError) no case clause matching: {:ok, %HTTPoison.Response{body: "", headers: [{"Server", "AkamaiGHost"}, {"Content-Length", "0"}, {"Location", "https://www.usda.gov/data.json"}, {"Date", "Fri, 16 Mar 2018 14:49:21 GMT"}, {"Connection", "keep-alive"}, {"Strict-Transport-Security", "max-age=31536000; preload"}, {"Content-Security-Policy", "upgrade-insecure-requests;"}, {"X-Content-Security-Policy", "upgrade-insecure-requests;"}], request_url: "http://www.usda.gov/data.json", status_code: 301}}
    profile/get_usda_json.exs:2: (file)
    (elixir) lib/code.ex:376: Code.require_file/2
    (mix) lib/mix/tasks/run.ex:102: Mix.Tasks.Run.run/5
    (mix) lib/mix/tasks/run.ex:55: Mix.Tasks.Run.run/1
    (mix) lib/mix/task.ex:301: Mix.Task.run_task/3
```