### PR TITLE
Fix small binary pattern match issue affecting changes past the 10th …

### DIFF
--- a/lib/json_diff_ex.ex
+++ b/lib/json_diff_ex.ex
@@ -70,7 +70,7 @@ defmodule JsonDiffEx do
   @default_strict_equality true
 
   @spec split_underscore_map({binary, list}) :: boolean
-  defp split_underscore_map({<<"_", _>>, [value, 0, 0]}) when is_map(value) do
+  defp split_underscore_map({<<"_", _::binary>>, [value, 0, 0]}) when is_map(value) do
     false
   end
   defp split_underscore_map(_) do
@@ -78,7 +78,7 @@ defmodule JsonDiffEx do
   end
 
   @spec split_underscore({binary, list}) :: boolean
-  defp split_underscore({<<"_", _>>, [_, 0, 0]}) do
+  defp split_underscore({<<"_", _::binary>>, [_, 0, 0]}) do
     false
   end
 

--- a/test/json_diff_ex_test.exs
+++ b/test/json_diff_ex_test.exs
@@ -285,4 +285,32 @@ defmodule JsonDiffExTest do
             "phone" => ["+1 (876) 456-3989", "+1 (895) 435-3714"], "registered" => ["2014-07-20T11:36:42 +04:00", "2015-03-11T11:45:43 +04:00"]}
     comparediff_patch(s1, s2, diff1)
   end
+
+  test "change eleventh item in list" do
+    list = Enum.to_list(1..100)
+    {first, [original | rest]} = Enum.split(list, 10)
+    changed = original * -1
+
+    obj1 = %{"primitives" => list}
+    obj2 = %{"primitives" => first ++ [changed | rest]}
+
+    diff = JsonDiffEx.diff(obj1, obj2)
+    patched = JsonDiffEx.patch(obj1, diff)
+
+    assert patched == obj2
+  end
+
+  test "change eleventh item in list of maps" do
+    list = Enum.map(1..100, fn num -> %{"val" => num} end)
+    {first, [original | rest]} = Enum.split(list, 10)
+    changed = Map.put(original, "value", "changed")
+
+    obj1 = %{"maps" => list}
+    obj2 = %{"maps" => first ++ [changed | rest]}
+
+    diff = JsonDiffEx.diff(obj1, obj2)
+    patched = JsonDiffEx.patch(obj1, diff)
+
+    assert patched == obj2
+  end
 end


### PR DESCRIPTION
…element in a list.

Noticed this when performing diffs of maps with embedded lists a couple thousand elements long, where the first changed element didn't occur until deep into the list.