### PR TITLE
Handle large list with updates and new rows

### DIFF
--- a/lib/json_diff_ex.ex
+++ b/lib/json_diff_ex.ex
@@ -126,7 +126,7 @@ defmodule JsonDiffEx do
     end)
     |> elem(1)
 
-    diff = case Enum.split_while(new_list, &split_underscore_map/1) do
+    diff = case Enum.split_with(new_list, &split_underscore_map/1) do
       {[], []} -> new_list
       {_, []} -> new_list
       {check, deleted} ->
@@ -228,6 +228,7 @@ defmodule JsonDiffEx do
     |> Enum.map(fn
      {s_index, value} -> {String.to_integer(s_index), value}
     end)
+    |> Enum.sort_by(fn {idx, _v} -> idx end)
     |> Enum.reduce(new_list, fn
       {index, %{} = diff_map}, acc ->
         List.update_at(acc, index, &do_patch(&1, diff_map))

--- a/test/json_diff_ex_test.exs
+++ b/test/json_diff_ex_test.exs
@@ -313,10 +313,44 @@ defmodule JsonDiffExTest do
 
     assert patched == obj2
   end
-  
+
   test "null fields are preserved after patching" do
     obj1 = %{"name" => "original", "should_be_nil" => nil}
     obj2 = %{"name" => "changed", "should_be_nil" => nil}
+
+    diff = JsonDiffEx.diff(obj1, obj2)
+    patched = JsonDiffEx.patch(obj1, diff)
+
+    assert patched == obj2
+  end
+
+  test "change items and add items in large list" do
+    list = Enum.map(1..1000, fn num -> %{"val" => num} end)
+    changed = %{"val" => "changed", "a_new_field" => true}
+
+    # Replace some values at random positions
+    new_list =
+      [1, 33, 127, 68, 374, 782, 683, 237, 912]
+      |> Enum.reduce(list, fn idx, acc ->
+        List.replace_at(acc, idx, changed)
+      end)
+
+    # Insert some new values at random positions
+    new_list =
+      [17, 112, 678, 234, 922, 63, 876, 5]
+      |> Enum.reduce(new_list, fn idx, acc ->
+        List.insert_at(acc, idx, changed)
+      end)
+
+    # Add some items to the end of the list
+    new_list =
+      1..20
+      |> Enum.reduce(new_list, fn _, acc ->
+        List.insert_at(acc, -1, changed)
+      end)
+
+    obj1 = %{"maps" => list}
+    obj2 = %{"maps" => new_list}
 
     diff = JsonDiffEx.diff(obj1, obj2)
     patched = JsonDiffEx.patch(obj1, diff)


### PR DESCRIPTION
I found another issue around large embedded lists today. There was a change in Elixir (or maybe Erlang?) several versions back where the underlying structure used for maps changed once it hit a certain number of keys (somewhere between 30-60, if I recall correctly), and which point the order of the keys changed. So the code in `do_diff/3` that expects all the index keys to come before all the `_index` keys stops working once the list reaches a certain size.

The same issue shows up in the patching side, where once there's enough keys you can't be sure that the list operations are going to occur from index 0-N... they might be out-of-order.

These changes fix those issues, but they do add some overhead and probably slow things down, as it adds a complete loop through the list of changes when building the diff, and I'm not sure how much extra overhead of the `Enum.sort_by/2` call adds.

You can run this test against an unpatched version to see the issues:

```
list = Enum.map(1..1000, fn num -> %{"val" => num} end)
changed = %{"val" => "changed", "a_new_field" => true}

# Replace some values at random positions
new_list =
  [1, 33, 127, 68, 374, 782, 683, 237, 912]
  |> Enum.reduce(list, fn idx, acc ->
    List.replace_at(acc, idx, changed)
  end)

# Insert some new values at random positions
new_list =
  [17, 112, 678, 234, 922, 63, 876, 5]
  |> Enum.reduce(new_list, fn idx, acc ->
    List.insert_at(acc, idx, changed)
  end)

# Add some items to the end of the list
new_list =
  1..20
  |> Enum.reduce(new_list, fn _, acc ->
    List.insert_at(acc, -1, changed)
  end)

obj1 = %{"maps" => list}
obj2 = %{"maps" => new_list}

diff = JsonDiffEx.diff(obj1, obj2)
patched = JsonDiffEx.patch(obj1, diff)

assert patched == obj2
```