### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ First, add JsonDiffEx to your `mix.exs` dependencies:
 
 ```elixir
 def deps do
-  [{:json_diff_ex, "~> 0.5.0"}]
+  [{:json_diff_ex, "~> 0.7.0"}]
 end
 ```
 


### PR DESCRIPTION
Update json_diff_ex version in README to improve installation experience.

This pull request updates the `json_diff_ex` version in the README file from `~> 0.5.0` to `~> 0.7.0`.

This change resolves the "undefined variable 'package'" and "undefined variable 'deps'" errors that users may encounter when following the HexDocs/GitHub instructions for installing version 0.5.0. By updating the dependency, we ensure a smoother and more reliable installation process for new users.